### PR TITLE
Fix/incorrect module naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@ format.
 
 ***
 
+## [UNRELEASED]
+
+### Fixed
+
+ - Minor bug in `install.py` that meant built-on-install modules had the
+   incorrect name
+ - Major bug in `build.py` that would not copy included assets
+
+***
+
 ## [0.1.2] - 2025-06-24
 
 ### Fixed

--- a/example/amor.toml
+++ b/example/amor.toml
@@ -19,4 +19,4 @@ build = "echo \"No build script defined!\""
 
 [dependencies]
 zip = "matiasah/zip@None=f7808d24127e7ea8458c6045b61a69295e102ec5"
-luafilesystem = "lunarmodules/luafilesystem@None=09511782201302ade916d4b250d01a6c61b56844"
+lfs = "lunarmodules/luafilesystem@None=09511782201302ade916d4b250d01a6c61b56844"

--- a/src/build.py
+++ b/src/build.py
@@ -9,7 +9,7 @@ def buildOpt(args: Namespace):
     from luaparser import ast, astnodes
     from pickle import load as pload, dump as pdump
     from shutil import rmtree, copytree, copyfile
-    from fnmatch import filter as fnmatch
+    from fnmatch import fnmatch
     try:
         from lupa.lua54 import LuaRuntime
     except ImportError:
@@ -162,9 +162,11 @@ def buildOpt(args: Namespace):
         directory = listdir(dir)
         
         for p in directory:
+            print(p)
             if path.isdir(f"{dir}/{p}"):
                 asset_dict[p] = recRegisterAssets(f"{dir}/{p}", {})
             else:
+                print(f"Checking {dir}/{p} against", *include)
                 for pattern in include:
                     if fnmatch(p, pattern):
                         print(f"Found {dir}/{p}")
@@ -197,6 +199,7 @@ def buildOpt(args: Namespace):
 
     print(include)
     assets = recRegisterAssets(f"./{source_dir}")
+    print(*assets)
     if len(assets.keys()) > 0:
         print("Found assets")
         print(assets)

--- a/src/install.py
+++ b/src/install.py
@@ -111,13 +111,24 @@ def installOpt(args: Namespace):
                 lua = LuaRuntime()
                 build_modules = dict(lua.execute(''.join(rspec))) # type: ignore
                 print(build_modules)
-                mods = [mod for mod in build_modules["modules"]] # type: ignore
+                mods: list[str] = [mod for mod in build_modules["modules"]] # type: ignore
+                package: str | None = build_modules['package'] # type: ignore
 
                 print(*mods)
                 print(build_modules["package"]) # type: ignore
-                if build_modules["package"] is not None: # type: ignore
-                    mod_name = build_modules["package"] # type: ignore
-                elif len(mods) > 0:
+                has_package = package is not None
+                renamed_mod = list(filter(lambda m: '.' not in m, mods))
+                mismatch_module_name = len(renamed_mod) != 0 and package not in renamed_mod
+                print(*renamed_mod)
+
+                if has_package:
+                    print('has package', package)
+                    mod_name = package
+                if mismatch_module_name:
+                    print('but has mismatch', renamed_mod[0])
+                    mod_name = renamed_mod[0]
+                if not has_package and not mismatch_module_name and len(mods) > 0:
+                    print('fallback')
                     mod_name = mods[0]
 
                 if path.exists(f"./.amor/{mod_name}"):


### PR DESCRIPTION
Built-on-install modules were being occassionally mis-named in the `.amor` output folder. This has now been fixed by checking the included rockspec for non-period-separated-values that replace the package name.

Also fixed build bug that would not copy over included assets.