### PR TITLE
Added 'build --clean' option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ format.
 
 ## [UNRELEASED]
 
+### Added
+
+ - Calling `amor build --clean` will remove the existing build directory before
+   beginning
+
 ### Fixed
 
  - Minor bug in `install.py` that meant built-on-install modules had the

--- a/src/build.py
+++ b/src/build.py
@@ -38,6 +38,9 @@ def buildOpt(args: Namespace):
     lua_path = f'./.amor/?.lua;./{source_dir}/?.lua;./.amor/?/init.lua;{str(lpath)};'
     lua_cpath = f';./.amor/?.so;./.amor/?/?.so;./{source_dir}/?.so;{str(cpath)};'
     
+    if args.clean:
+        rmtree(f'./{build_dir}')
+
     if not path.exists('./.bld'):
         mkdir('./.bld')
 

--- a/src/main.py
+++ b/src/main.py
@@ -78,6 +78,8 @@ run.set_defaults(func=runOpt)
 # Build
 build = subparsers.add_parser("build", aliases=["b"], help="Build project into\
         single directory for Löve.")
+build.add_argument("--clean", "-c", action="store_true", help="Remove existing\
+                   build folder contents.")
 build.set_defaults(func=buildOpt)
 
 # Love


### PR DESCRIPTION
Running `amor build --clean` will remove the existing build directory before beginning the build process.