### PR TITLE
Fixed dependency no copy on no build script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ format.
 
 ***
 
+## [UNRELEASED]
+
+### Fixed
+
+ - Major bug in install script that skips built dependencies that do not have a
+   build option (i.e. no rockspec)
+
+***
+
 ## [0.2.0] - 2025-06-26
 
 ### Added

--- a/src/install.py
+++ b/src/install.py
@@ -91,6 +91,8 @@ def installOpt(args: Namespace):
         makefiles = [file for file in dir_content if "Makefile" in file]
         
         built_from_spec = False
+        built_from_rockspec = False
+        built_from_makefile = False
         try:
             if len(rockspecs) > 0:
                 print('Building from Rockspec...')
@@ -145,6 +147,7 @@ def installOpt(args: Namespace):
                     except:
                         print(f"Uh oh! {mod_name} could not be built!")
                         raise
+                built_from_rockspec = True
 
             elif len(makefiles) > 0:
                 print('Building from Makefile...')
@@ -167,12 +170,15 @@ def installOpt(args: Namespace):
                 for line in res.stdout.splitlines(): print(line)
 
                 res.check_returncode()
+                built_from_makefile = True
         except:
             print('Something went wrong whilst building, attempting source \
                   copy...')
         else:
-            built_from_spec = True
+            print('No errors!')
+            built_from_spec = built_from_rockspec or built_from_makefile
         finally:
+            print('Final checks...')
             if not built_from_spec:
                 print('No build option found! Copying files...')
 


### PR DESCRIPTION
If a dependency lacked a rockspec or makefile, its contents would not be copied as expected.