### PR TITLE
Dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ format.
 
 ***
 
+## [UNRELEASED]
+
+### Fixed
+
+ - Build script now ignores `require`-ing of modules bundled with Love
+
+***
+
 ## [0.2.1] - 2025-06-28
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ format.
 ### Fixed
 
  - Build script now ignores `require`-ing of modules bundled with Love
+ - Install script now creates an `init.lua` for installed modules that lack them
+   even if they are not a compiled `*.so`
 
 ***
 

--- a/example/src/lib/moduleA.lua
+++ b/example/src/lib/moduleA.lua
@@ -1,5 +1,5 @@
 local zip = require('zip')
-local lfs = require('luafilesystem.lfs')
+local lfs = require('lfs')
 
 return {
     hello = function ()

--- a/src/build.py
+++ b/src/build.py
@@ -10,7 +10,6 @@ def buildOpt(args: Namespace):
     from pickle import load as pload, dump as pdump
     from shutil import rmtree, copytree, copyfile
     from fnmatch import fnmatch
-    from constants import love_builtins
     try:
         from lupa.lua54 import LuaRuntime
     except ImportError:
@@ -22,7 +21,7 @@ def buildOpt(args: Namespace):
             except ImportError:
                 from lupa.lua51 import LuaRuntime
 
-    from constants import init_lua_template
+    from constants import init_lua_template_so, init_lua_template_lua, love_builtins
 
     with open('amor.toml', 'r') as conf_file:
         conf = load(conf_file)
@@ -115,10 +114,17 @@ def buildOpt(args: Namespace):
                 rmtree(out_dir)
             copytree('/'.join(copy_path), f"./{build_dir}/ext/{mod_dir}")
             print("Copied", mod_map[key])
+            no_init = 'init.lua' not in listdir(f"./{build_dir}/ext/{mod_dir}")
             if mod_map[key].endswith('.so'):
-                init_lua_content = init_lua_template.replace("{mod}", key)
+                init_lua_content = init_lua_template_so.replace("{mod}", key)
                 with open(f"./{build_dir}/ext/{mod_dir}/init.lua", "w") as init_file:
                     init_file.writelines(init_lua_content.splitlines(keepends=True))
+                print('Wrote init.lua for *.so')
+            elif no_init:
+                init_lua_content = init_lua_template_lua.replace("{mod}", key)
+                with open(f"./{build_dir}/ext/{mod_dir}/init.lua", "w") as init_file:
+                    init_file.writelines(init_lua_content.splitlines(keepends=True))
+                print('Wrote init.lua for *.lua')
 
     
     def recCompile(directory: str):

--- a/src/build.py
+++ b/src/build.py
@@ -10,6 +10,7 @@ def buildOpt(args: Namespace):
     from pickle import load as pload, dump as pdump
     from shutil import rmtree, copytree, copyfile
     from fnmatch import fnmatch
+    from constants import love_builtins
     try:
         from lupa.lua54 import LuaRuntime
     except ImportError:
@@ -66,7 +67,10 @@ def buildOpt(args: Namespace):
                         res = lua.eval(f'package.searchpath("{mod.s}",\
                                 "{lua_path+lua_cpath}")')
                         if '(None,' in str(res):
-                             print(f'Could not find {mod.s}')
+                             if mod.s in love_builtins:
+                                print(f"{mod.s} included with Love")
+                             else:
+                                print(f'Could not find {mod.s}')
                              continue
 
                         mod_map[mod.s] = str(res)

--- a/src/constants.py
+++ b/src/constants.py
@@ -57,12 +57,19 @@ end
 """.splitlines(keepends=True)
 
 # Template for init.lua for C modules
-init_lua_template = """\
+init_lua_template_so = """\
 local Path = (...):gsub("%p", "/")
 local RequirePath = ...
 local {mod} = package.loadlib("{mod}", Path.."/{mod}.so")
 package.loaded["{mod}"] = {mod}
 return {mod}
+"""
+
+init_lua_template_lua = """\
+local RequirePath = ...
+local mod = require "{mod}"
+package.loaded["{mod}"] = mod
+return mod
 """
 
 love_builtins = [

--- a/src/constants.py
+++ b/src/constants.py
@@ -65,4 +65,8 @@ package.loaded["{mod}"] = {mod}
 return {mod}
 """
 
-
+love_builtins = [
+        "enet",
+        "socket",
+        "utf8"
+        ]


### PR DESCRIPTION
### Fixed

 - Build script now ignores `require`-ing of modules bundled with Love
 - Install script now creates an `init.lua` for installed modules that lack them
   even if they are not a compiled `*.so`