### PR TITLE
Dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ format.
 
 ***
 
-## [UNRELEASED]
+## [0.3.0] - 2025-07-03
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,15 @@ format.
 
 ## [UNRELEASED]
 
+### Changed
+
+ - Updated `.luarc.json` default to include `$schema`
+ - Updated `.gitignore` to ignore `.bld/` by default
+
 ### Fixed
 
- - Long chains of function calls no longer gain a line-break on compilation
+ - Long chains of lua function calls no longer gain a line-break on compilation
+ - Default `.luarc.json` is properly formatted
 
 ***
 

--- a/src/constants.py
+++ b/src/constants.py
@@ -28,19 +28,19 @@ default_conf = {
 
 luarc = """\
 {
-    "Lua": {
-        "runtime": {
-            "version": "Lua 5.4"
-        }
+    "$schema": "https://raw.githubusercontent.com/sumneko/vscode-lua/master/setting/schema.json",
+    "runtime": {
+        "version": "Lua 5.4"
     }
 }
 """.splitlines(keepends=True)
 
 # Default .gitignore for projects
 gitignore_lines = """\
-/build
-/dist
-/.amor
+.amor/
+.bld/
+build/
+dist/
 """.splitlines(keepends=True)
 
 # Default .gitattributes for projects

--- a/src/main.py
+++ b/src/main.py
@@ -9,9 +9,9 @@ from build import buildOpt
 from love import loveOpt
 
 # amor version
-__version__ = '0.2.2'
+__version__ = '0.3.0'
 __author__ = 'Sam Drage (github: snailcreature)'
-__date__ = '2025-06-29'
+__date__ = '2025-07-03'
 
 
 def defaultOpt(args: Namespace):


### PR DESCRIPTION
## [0.4.0] - 2025-08-02

### Changed

 - Updated `.luarc.json` default to include `$schema`
 - Updated `.gitignore` to ignore `.bld/` by default

### Fixed

 - Long chains of lua function calls no longer gain a line-break on compilation
 - Default `.luarc.json` is properly formatted